### PR TITLE
Feature : Add support for passing additional view data via with() (and extraData() alias) in TemplateMail

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,33 @@ Mail::to($customer->email)->send(
 
 `TemplateMail` is automatically queued. Configure the queue connection and name in `config/fin-mail.php`.
 
+#### Passing extra view data
+
+`models()` is for token replacement (`{{ user.name }}`). For variables you want available directly in the Blade template — without going through the token system — use `with()` or its `extraData()` alias:
+
+```php
+TemplateMail::make('order-confirmation')
+    ->models(['user' => $user])
+    ->with('trackingUrl', $tracking->url)
+    // or pass an array:
+    ->extraData([
+        'orderItems' => $order->items,
+        'currency' => 'EUR',
+    ]);
+```
+
+After publishing the package views (`php artisan vendor:publish --tag=fin-mail-views`), the variables are available directly in the Blade template:
+
+```blade
+<a href="{{ $trackingUrl }}">Track your order</a>
+
+@foreach ($orderItems as $item)
+    {{ $item->name }} — {{ $item->price }} {{ $currency }}
+@endforeach
+```
+
+The default keys (`body`, `preheader`, `theme`, `branding`) remain available — extra data is merged on top.
+
 ### Adding "Send Email" to any resource
 
 ```php

--- a/src/Mail/TemplateMail.php
+++ b/src/Mail/TemplateMail.php
@@ -51,9 +51,6 @@ class TemplateMail extends Mailable implements ShouldQueue
 
     protected ?SentEmail $sentEmailLog = null;
 
-    /** @var array<string, mixed> */
-    protected array $extraData = [];
-
     protected ?string $overrideSubject = null;
 
     protected ?string $overrideBody = null;

--- a/src/Mail/TemplateMail.php
+++ b/src/Mail/TemplateMail.php
@@ -51,6 +51,9 @@ class TemplateMail extends Mailable implements ShouldQueue
 
     protected ?SentEmail $sentEmailLog = null;
 
+    /** @var array<string, mixed> */
+    protected array $extraData = [];
+
     protected ?string $overrideSubject = null;
 
     protected ?string $overrideBody = null;
@@ -106,6 +109,22 @@ class TemplateMail extends Mailable implements ShouldQueue
 
         return $this;
     }
+
+    /*public function extraData(array $data): static
+    {
+        $this->extraData = array_merge($this->extraData, $data);
+
+        return $this;
+    }*/
+    public function extraData(array $data): static
+    {
+        foreach ($data as $key => $value) {
+            $this->with($key, $value);
+        }
+
+        return $this;
+    }
+
 
     public function overrideSubject(string $subject): static
     {
@@ -183,17 +202,21 @@ class TemplateMail extends Mailable implements ShouldQueue
 
         return new Content(
             view: 'fin-mail::email.default',
-            with: [
-                'body' => $this->overrideBody
-                    ? app(TokenReplacer::class)->replace(
-                        $this->stripMergeTagSpans($this->overrideBody),
-                        $this->models,
-                    )
-                    : $rendered['body'],
-                'preheader' => $rendered['preheader'],
-                'theme' => $theme?->resolvedColors() ?? EmailTheme::defaultColors(),
-                'branding' => $this->resolveBranding(),
-            ],
+            with: array_merge(
+                [
+                    'body' => $this->overrideBody
+                        ? app(TokenReplacer::class)->replace(
+                            $this->stripMergeTagSpans($this->overrideBody),
+                            $this->models,
+                        )
+                        : $rendered['body'],
+                    'preheader' => $rendered['preheader'],
+                    'theme' => $theme?->resolvedColors() ?? EmailTheme::defaultColors(),
+                    'branding' => $this->resolveBranding(),
+                ],
+                $this->viewData
+                //$this->extraData
+            )
         );
     }
 

--- a/src/Mail/TemplateMail.php
+++ b/src/Mail/TemplateMail.php
@@ -110,12 +110,6 @@ class TemplateMail extends Mailable implements ShouldQueue
         return $this;
     }
 
-    /*public function extraData(array $data): static
-    {
-        $this->extraData = array_merge($this->extraData, $data);
-
-        return $this;
-    }*/
     public function extraData(array $data): static
     {
         foreach ($data as $key => $value) {
@@ -124,7 +118,6 @@ class TemplateMail extends Mailable implements ShouldQueue
 
         return $this;
     }
-
 
     public function overrideSubject(string $subject): static
     {
@@ -215,7 +208,6 @@ class TemplateMail extends Mailable implements ShouldQueue
                     'branding' => $this->resolveBranding(),
                 ],
                 $this->viewData
-                //$this->extraData
             )
         );
     }

--- a/tests/Unit/TemplateMailExtraDataTest.php
+++ b/tests/Unit/TemplateMailExtraDataTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use FinityLabs\FinMail\Mail\TemplateMail;
+use FinityLabs\FinMail\Models\EmailTemplate;
+
+beforeEach(function () {
+    EmailTemplate::create([
+        'key' => 'extra-data-test',
+        'name' => ['en' => 'Extra Data Test'],
+        'category' => 'transactional',
+        'subject' => ['en' => 'Hello'],
+        'body' => ['en' => '<p>Body</p>'],
+        'is_active' => true,
+    ]);
+});
+
+it('passes extra data via with() to the view', function () {
+    $mail = TemplateMail::make('extra-data-test')
+        ->with('customVar', 'hello world');
+
+    expect($mail->viewData)->toHaveKey('customVar')
+        ->and($mail->viewData['customVar'])->toBe('hello world');
+});
+
+it('passes extra data via extraData() alias to the view', function () {
+    $mail = TemplateMail::make('extra-data-test')
+        ->extraData([
+            'foo' => 'bar',
+            'count' => 42,
+        ]);
+
+    expect($mail->viewData)->toHaveKey('foo')
+        ->and($mail->viewData['foo'])->toBe('bar')
+        ->and($mail->viewData['count'])->toBe(42);
+});
+
+it('returns the mailable instance for chaining', function () {
+    $mail = TemplateMail::make('extra-data-test');
+
+    expect($mail->extraData(['key' => 'value']))->toBe($mail)
+        ->and($mail->with('another', 'value'))->toBe($mail);
+});


### PR DESCRIPTION
This PR improves the flexibility of **TemplateMail** by allowing developers to pass additional variables directly to the Blade view using Laravel’s native `with()` method.

It also introduces an `extraData()` alias for convenience and readability in a mail-specific context.

Currently, **TemplateMail** allows passing data through `models()`, which is primarily intended for token replacement.

However, there is no straightforward way to pass additional view-specific variables without overloading models() or modifying the template structure.

This PR provides a clean separation between:

- Models → used for token replacement
- View data → used directly in Blade templates

So this PR introduce 2 news methods :

_1. Native support for with()_
Since **TemplateMail** extends Laravel’s Mailable, this PR leverages the existing `with()` method to inject variables into the view.
```php
TemplateMail::make('template-key-id')
    ->models([...])
    ->with('customVar', 'value')
     //or
    ->with(['foo' => 'bar'])
```
In Blade view (after publishing the package views with the php artisan vendor:publish --tag=fin-mail-views command)
```blade
{{-- Content --}}
<tr>
     <td class="email-content" style="background-color: {{ $theme['content_bg'] ?? '#ffffff' }}; border-radius: 8px; padding: 40px 30px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 16px; line-height: 1.6; color: {{ $theme['text'] ?? '#333333' }};">
        {{ $customVar }}
        {!! \FinityLabs\FinMail\Helpers\InlineStyler::apply($body, $theme) !!}
    </td>
</tr>
```

_2. Added extraData() alias_
For improved readability in a mail context:
```php
TemplateMail::make('template-key-id')
    ->models([...])
    ->extraData([
        'customVar' => 'value',
    ]);
```
Internally, this simply proxies to `with()`

_View data integration_
The `content()` method has been updated to merge:

- default template variables (body, theme, etc.)
- Laravel’s internal $viewData (populated via with())

I can also update the README with a short section explaining this usage.

Thank you very much