### PR TITLE
Add support for overriding the default email view

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,20 @@ After publishing the package views (`php artisan vendor:publish --tag=fin-mail-v
 
 The default keys (`body`, `preheader`, `theme`, `branding`) remain available — extra data is merged on top.
 
+#### Using a custom email view
+
+By default, FinMail renders emails using the built-in `fin-mail::email.default` view.
+
+You can override the view on a per-email basis:
+
+```php
+TemplateMail::make('welcome-email')
+    ->models(['user' => $user])
+    ->overrideView('emails.custom-layout');
+```
+
+The custom view receives the same variables as the default view (`$body`, `$preheader`, `$theme`, `$branding`) as well as any data provided via `with()` or `extraData()`.
+
 ### Adding "Send Email" to any resource
 
 ```php

--- a/src/Mail/TemplateMail.php
+++ b/src/Mail/TemplateMail.php
@@ -55,6 +55,8 @@ class TemplateMail extends Mailable implements ShouldQueue
 
     protected ?string $overrideBody = null;
 
+    protected ?string $overrideView = null;
+
     /** @var array{address: string, name: ?string}|null */
     protected ?array $overrideFrom = null;
 
@@ -144,6 +146,13 @@ class TemplateMail extends Mailable implements ShouldQueue
         return $this;
     }
 
+    public function overrideView(string $view): static
+    {
+        $this->overrideView = $view;
+
+        return $this;
+    }
+
     public function withLogging(?SentEmail $log = null): static
     {
         $this->sentEmailLog = $log;
@@ -191,7 +200,7 @@ class TemplateMail extends Mailable implements ShouldQueue
         $theme = $this->emailTemplate->theme ?? EmailTheme::getDefault();
 
         return new Content(
-            view: 'fin-mail::email.default',
+            view: $this->overrideView ?? 'fin-mail::email.default',
             with: array_merge(
                 [
                     'body' => $this->overrideBody


### PR DESCRIPTION
This PR introduces the ability to override the default email view used by TemplateMail.

In some application, we needed to use a custom email layout shared across multiple mailables while still managing email content through Fin Mail templates. The current implementation requires overriding package views globally, whereas this approach allows customization on a per-email basis without affecting existing behavior.

Currently, all emails are rendered using the package view: `fin-mail::email.default`

While this works well for most use cases, some applications require a completely custom email layout while still benefiting from:

- database-driven templates
- token replacement
- theme management
- email logging
- attachment handling

This PR adds a new fluent method:
```php
TemplateMail::make('invoice-sent')
    ->overrideView('emails.custom-layout');
```

This change is fully backward compatible.

If overrideView() is not called, the existing behavior remains unchanged and emails continue to use the default package view.

Readme updated accordingly.