### PR TITLE
test: cover overrideView() on TemplateMail

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ namespace FinityLabs\FinMail\Tests;
 use FinityLabs\FinMail\FinMailServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Spatie\LaravelSettings\LaravelSettingsServiceProvider;
 
 class TestCase extends Orchestra
 {
@@ -23,6 +24,7 @@ class TestCase extends Orchestra
     {
         return [
             FinMailServiceProvider::class,
+            LaravelSettingsServiceProvider::class,
         ];
     }
 

--- a/tests/Unit/TemplateMailOverrideViewTest.php
+++ b/tests/Unit/TemplateMailOverrideViewTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use FinityLabs\FinMail\Mail\TemplateMail;
+use FinityLabs\FinMail\Models\EmailTemplate;
+use FinityLabs\FinMail\Settings\BrandingSettings;
+
+beforeEach(function () {
+    BrandingSettings::fake(BrandingSettings::defaults(), loadMissingValues: false);
+
+    EmailTemplate::create([
+        'key' => 'override-view-test',
+        'name' => ['en' => 'Override View Test'],
+        'category' => 'transactional',
+        'subject' => ['en' => 'Hello'],
+        'body' => ['en' => '<p>Body</p>'],
+        'is_active' => true,
+    ]);
+});
+
+it('renders with the default package view when no override is set', function () {
+    $mail = TemplateMail::make('override-view-test');
+
+    expect($mail->content()->view)->toBe('fin-mail::email.default');
+});
+
+it('renders with a custom view when overrideView() is called', function () {
+    $mail = TemplateMail::make('override-view-test')
+        ->overrideView('emails.custom-layout');
+
+    expect($mail->content()->view)->toBe('emails.custom-layout');
+});
+
+it('returns the mailable instance for chaining', function () {
+    $mail = TemplateMail::make('override-view-test');
+
+    expect($mail->overrideView('emails.custom-layout'))->toBe($mail);
+});
+
+it('passes the default view variables to a custom view', function () {
+    $mail = TemplateMail::make('override-view-test')
+        ->overrideView('emails.custom-layout')
+        ->with('customVar', 'hello world');
+
+    $with = $mail->content()->with;
+
+    expect($with)->toHaveKeys(['body', 'preheader', 'theme', 'branding', 'customVar'])
+        ->and($with['customVar'])->toBe('hello world');
+});


### PR DESCRIPTION
Follow-up to #14, as promised in the merge comment.

Adds unit tests for the new overrideView() method:

- the default package view (fin-mail::email.default) is used when no override is set
- overrideView() swaps the view used by content()
- the method returns the mailable for chaining
- a custom view still receives the default variables (body, preheader, theme, branding) plus with() data

Also registers Spatie's LaravelSettingsServiceProvider in the package TestCase (matching how the package runs in real apps via auto-discovery) and fakes BrandingSettings, so tests can build content() without a settings table.